### PR TITLE
fix(nav): replace * selector with concrete ones

### DIFF
--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -1,34 +1,32 @@
 import { css, Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 import { forwardRef, HTMLAttributes, ReactNode } from "react";
-import {
-  ColorProps,
-  SpaceProps,
-  TypographyProps,
-  LayoutProps,
-  FlexboxProps,
-  GridProps,
-  BackgroundProps,
-  BorderProps,
-  PositionProps,
-  ShadowProps,
-  color,
-} from "styled-system";
 import { Icon } from "./Icon";
 import { ExternalWindow } from "./icons/shade";
 import {
-  CursorProps,
+  background,
+  BackgroundProps,
+  border,
+  BorderProps,
+  color,
+  ColorProps,
   compose,
   cursor,
-  space,
-  typography,
-  layout,
+  CursorProps,
   flexbox,
+  FlexboxProps,
   grid,
-  background,
-  border,
+  GridProps,
+  layout,
+  LayoutProps,
   position,
+  PositionProps,
   shadow,
+  ShadowProps,
+  space,
+  SpaceProps,
+  typography,
+  TypographyProps,
 } from "./system";
 
 export type StyledLinkProps = ColorProps &

--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -1,11 +1,12 @@
 import { css } from "@emotion/react";
 import { Fragment, ReactNode, useRef, useState } from "react";
 import { Avatar } from "./Avatar";
-import { Box, BoxProps } from "./Box";
+import { Box } from "./Box";
 import { Button, ButtonProps } from "./Button";
 import { useClickOutsideListener } from "./hooks";
 import { Icon, IconProps } from "./Icon";
 import { Menu, X } from "./icons/outline";
+import { Link, LinkProps } from "./Link";
 import { Logo } from "./Logo";
 import { Text } from "./Text";
 
@@ -18,7 +19,7 @@ type NavLinkProps = {
 type ProfileLinkProps = {
   label?: string;
   href?: string;
-  onClick?: BoxProps["onClick"];
+  onClick?: LinkProps["onClick"];
 };
 
 type TrayIconProps = {
@@ -30,8 +31,7 @@ type TrayIconProps = {
 
 export const TrayIcon = ({ icon, badge, label, href }: TrayIconProps) => {
   return (
-    <Box
-      as="a"
+    <Link
       p="xxsmall"
       display="flex"
       alignItems="center"
@@ -50,7 +50,7 @@ export const TrayIcon = ({ icon, badge, label, href }: TrayIconProps) => {
       <Icon badge={badge} color="currentColor">
         {icon}
       </Icon>
-    </Box>
+    </Link>
   );
 };
 
@@ -72,7 +72,7 @@ export type NavItemProps = {
   active?: boolean;
   variant?: "primary" | "secondary" | "menu";
   href?: string;
-  onClick?: BoxProps["onClick"];
+  onClick?: LinkProps["onClick"];
 };
 
 const responsiveDisplay = ["none", "block"];
@@ -84,7 +84,7 @@ export const NavItem = ({
   href,
   onClick,
 }: NavItemProps) => {
-  let textColor: BoxProps["textColor"] = "primary.50";
+  let textColor: LinkProps["textColor"] = "primary.50";
   switch (variant) {
     case "primary":
       textColor = "primary.50";
@@ -97,8 +97,7 @@ export const NavItem = ({
       break;
   }
   return (
-    <Box
-      as="a"
+    <Link
       href={href}
       onClick={onClick}
       cursor="pointer"
@@ -112,6 +111,9 @@ export const NavItem = ({
       css={(theme) => [
         css`
           user-select: none;
+          cursor: pointer;
+          display: inline-block;
+          color: ${textColor};
         `,
         active &&
           css`
@@ -149,7 +151,7 @@ export const NavItem = ({
       ]}
     >
       {children}
-    </Box>
+    </Link>
   );
 };
 
@@ -238,7 +240,7 @@ export const Nav = ({ logo, tray, profile, links, profileLinks }: NavProps) => {
                       margin: 0;
                     }
 
-                    & > * {
+                    & > a {
                       display: inline-block;
                       margin-left: 16px;
                     }
@@ -263,7 +265,8 @@ export const Nav = ({ logo, tray, profile, links, profileLinks }: NavProps) => {
                 alignItems="center"
                 marginY="small"
                 css={css`
-                  & > * {
+                  & > a,
+                  & > div {
                     margin-left: 16px;
                   }
                 `}
@@ -318,7 +321,7 @@ export const Nav = ({ logo, tray, profile, links, profileLinks }: NavProps) => {
                           boxShadow="small"
                           overflow="hidden"
                           css={css`
-                            & > * {
+                            & > a {
                               display: block !important;
                             }
                           `}
@@ -365,7 +368,7 @@ export const Nav = ({ logo, tray, profile, links, profileLinks }: NavProps) => {
                 & > :nth-of-type(1) {
                   margin-top: 0;
                 }
-                & > * {
+                & > a {
                   display: block !important;
                   margin-top: 8px;
                 }
@@ -401,7 +404,7 @@ export const Nav = ({ logo, tray, profile, links, profileLinks }: NavProps) => {
                 </Box>
                 <Box
                   css={css`
-                    & > * {
+                    & > a {
                       display: block !important;
                     }
                   `}

--- a/src/__snapshots__/Nav.test.tsx.snap
+++ b/src/__snapshots__/Nav.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`should match snapshot 1`] = `
   margin: 0;
 }
 
-.emotion-14>* {
+.emotion-14>a {
   display: inline-block;
   margin-left: 16px;
 }
@@ -138,6 +138,8 @@ exports[`should match snapshot 1`] = `
   min-width: 0;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
+  padding: 0;
+  margin: 0;
   cursor: pointer;
   display: inline-block;
   color: #EFFCF6;
@@ -148,12 +150,30 @@ exports[`should match snapshot 1`] = `
   font-size: 16px;
   font-weight: 600;
   border-radius: 10px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: inherit;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  cursor: pointer;
+  display: inline-block;
+  color: primary.50;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-16 svg {
+  margin-left: 8px;
+  width: auto;
+  height: 90%;
 }
 
 .emotion-16:focus {
@@ -203,7 +223,8 @@ exports[`should match snapshot 1`] = `
   }
 }
 
-.emotion-22>* {
+.emotion-22>a,
+.emotion-22>div {
   margin-left: 16px;
 }
 
@@ -212,6 +233,8 @@ exports[`should match snapshot 1`] = `
   min-width: 0;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
+  padding: 0;
+  margin: 0;
   padding: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -224,6 +247,21 @@ exports[`should match snapshot 1`] = `
   border-radius: 8px;
   position: relative;
   color: #EFFCF6;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: inherit;
+}
+
+.emotion-24 svg {
+  margin-left: 8px;
+  width: auto;
+  height: 90%;
 }
 
 .emotion-24:hover {
@@ -525,7 +563,7 @@ exports[`should match snapshot 1`] = `
   margin-top: 0;
 }
 
-.emotion-43>* {
+.emotion-43>a {
   display: block!important;
   margin-top: 8px;
 }
@@ -590,7 +628,7 @@ exports[`should match snapshot 1`] = `
   transition: all 0.2s ease;
 }
 
-.emotion-63>* {
+.emotion-63>a {
   display: block!important;
 }
 
@@ -599,6 +637,8 @@ exports[`should match snapshot 1`] = `
   min-width: 0;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
+  padding: 0;
+  margin: 0;
   cursor: pointer;
   display: inline-block;
   color: #8EEDC7;
@@ -609,12 +649,30 @@ exports[`should match snapshot 1`] = `
   font-size: 16px;
   font-weight: 600;
   border-radius: 10px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: inherit;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  cursor: pointer;
+  display: inline-block;
+  color: primary.200;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-65 svg {
+  margin-left: 8px;
+  width: auto;
+  height: 90%;
 }
 
 .emotion-65:focus {
@@ -695,7 +753,7 @@ exports[`should match snapshot 1`] = `
               display="flex"
             >
               <a
-                class="emotion-16 emotion-1"
+                class="emotion-16 emotion-17"
                 cursor="pointer"
                 display="inline-block"
                 font-size="standard"
@@ -705,7 +763,7 @@ exports[`should match snapshot 1`] = `
                 Home
               </a>
               <a
-                class="emotion-16 emotion-1"
+                class="emotion-16 emotion-17"
                 cursor="pointer"
                 display="inline-block"
                 font-size="standard"
@@ -726,7 +784,7 @@ exports[`should match snapshot 1`] = `
           >
             <a
               aria-label="Notifications"
-              class="emotion-24 emotion-1"
+              class="emotion-24 emotion-17"
               display="flex"
               href="#"
               title="Notifications"
@@ -808,7 +866,7 @@ exports[`should match snapshot 1`] = `
           class="emotion-43 emotion-1"
         >
           <a
-            class="emotion-16 emotion-1"
+            class="emotion-16 emotion-17"
             cursor="pointer"
             display="inline-block"
             font-size="standard"
@@ -818,7 +876,7 @@ exports[`should match snapshot 1`] = `
             Home
           </a>
           <a
-            class="emotion-16 emotion-1"
+            class="emotion-16 emotion-17"
             cursor="pointer"
             display="inline-block"
             font-size="standard"
@@ -867,7 +925,7 @@ exports[`should match snapshot 1`] = `
             class="emotion-63 emotion-1"
           >
             <a
-              class="emotion-65 emotion-1"
+              class="emotion-65 emotion-17"
               cursor="pointer"
               display="inline-block"
               font-size="standard"
@@ -877,7 +935,7 @@ exports[`should match snapshot 1`] = `
               Profile
             </a>
             <a
-              class="emotion-65 emotion-1"
+              class="emotion-65 emotion-17"
               cursor="pointer"
               display="inline-block"
               font-size="standard"


### PR DESCRIPTION
Emotion renders css style tags inline. This causes an issue when using * selectors, because the css style tags are also selected. In case of the Nav component this resulted in visible css style tags on first render. This is now resolved by using concret selectors e.g.: & > a