### PR TITLE
fix(package): cjs and esm are not detected

### DIFF
--- a/fixup
+++ b/fixup
@@ -1,0 +1,11 @@
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "concurrently yarn:build:*",
+    "build": "concurrently yarn:build:* && ./fixup",
     "build:esm": "tsc --project tsconfig.json --declaration --declarationDir dist/esm --module esnext --target es2015 --outDir dist/esm",
     "build:cjs": "tsc --project tsconfig.json --declaration --declarationDir dist/cjs --module commonjs --target es5 --outDir dist/cjs",
     "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",


### PR DESCRIPTION
I followed this guide
https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html . Maybe we
should only ship cjs??